### PR TITLE
Add toggle for player cone to ignore map zoom

### DIFF
--- a/Mappy/Controllers/Localization/Strings.resx
+++ b/Mappy/Controllers/Localization/Strings.resx
@@ -569,4 +569,7 @@ Open Map Window to populate data</value>
   <data name="UnacceptedQuestColor" xml:space="preserve">
     <value>Unaccepted Quest Color</value>
   </data>
+  <data name="ScaleCone" xml:space="preserve">
+    <value>Ignore Map Zoom</value>
+  </data>
 </root>

--- a/Mappy/Controllers/Localization/Strings.resx
+++ b/Mappy/Controllers/Localization/Strings.resx
@@ -572,4 +572,7 @@ Open Map Window to populate data</value>
   <data name="ScaleCone" xml:space="preserve">
     <value>Ignore Map Zoom</value>
   </data>
+  <data name="ScaleConeHelp" xml:space="preserve">
+    <value>Toggle will affect whether cone changes size when zooming in/out on map</value>
+  </data>
 </root>

--- a/Mappy/Controllers/Modules/Player.cs
+++ b/Mappy/Controllers/Modules/Player.cs
@@ -48,8 +48,8 @@ public unsafe class Player : ModuleBase {
         var playerPosition = Position.GetTexturePosition(player, map);
         var drawPosition = mapWindow.Viewport.GetImGuiWindowDrawPosition(playerPosition);
 
-        var lineLength = config.ConeRadius * mapWindow.Viewport.Scale;
-        
+        var lineLength = config.ScaleCone ? config.ConeRadius : config.ConeRadius * mapWindow.Viewport.Scale;
+
         var halfConeAngle = DegreesToRadians(config.ConeAngle) / 2.0f;
         
         DrawAngledLineFromCenter(drawPosition, lineLength, angle - halfConeAngle);

--- a/Mappy/Models/ModuleConfiguration/PlayerConfig.cs
+++ b/Mappy/Models/ModuleConfiguration/PlayerConfig.cs
@@ -24,7 +24,7 @@ public class PlayerConfig : IModuleConfig, IIconConfig, IPlayerColorConfig {
     [BoolConfig("ShowCone")]
     public bool ShowCone { get; set; } = true;
 
-    [BoolConfig("ScaleCone")]
+    [BoolConfig("ScaleCone", "ScaleConeHelp")]
     public bool ScaleCone { get; set; } = true;
 
     [FloatConfig("ConeRadius", 0.0f, 360.0f)]

--- a/Mappy/Models/ModuleConfiguration/PlayerConfig.cs
+++ b/Mappy/Models/ModuleConfiguration/PlayerConfig.cs
@@ -24,6 +24,9 @@ public class PlayerConfig : IModuleConfig, IIconConfig, IPlayerColorConfig {
     [BoolConfig("ShowCone")]
     public bool ShowCone { get; set; } = true;
 
+    [BoolConfig("ScaleCone")]
+    public bool ScaleCone { get; set; } = true;
+
     [FloatConfig("ConeRadius", 0.0f, 360.0f)]
     public float ConeRadius { get; set; } = 90.0f;
 


### PR DESCRIPTION
Add toggle into Player module for player cone:

![phhxpv](https://github.com/MidoriKami/Mappy/assets/7014583/dc33d8fb-60e2-454f-a25c-2e409bf3051e)

Unchecked: 

![k33bab](https://github.com/MidoriKami/Mappy/assets/7014583/f7856c68-cca4-4793-ad0d-e03803bbdd32)

Checked:

![7m4896](https://github.com/MidoriKami/Mappy/assets/7014583/4ba761fb-354f-47f9-a817-e045486f1db8)


Defaults to `False` to match current behavior.