### PR TITLE
Add subzone labels

### DIFF
--- a/Mappy/Controllers/Localization/Strings.resx
+++ b/Mappy/Controllers/Localization/Strings.resx
@@ -617,4 +617,7 @@ Open Map Window to populate data</value>
   <data name="UnCollapseWindow" xml:space="preserve">
     <value>Un-Collapse Window on Command</value>
   </data>
+  <data name="ShowSubzoneLabels" xml:space="preserve">
+    <value>Show Subzone Labels</value>
+  </data>
 </root>

--- a/Mappy/Controllers/Modules/MapIcons.cs
+++ b/Mappy/Controllers/Modules/MapIcons.cs
@@ -49,7 +49,7 @@ public class MapIcons : ModuleBase {
     private void DrawMarker(MapMarker marker, Map map) {
         var config = GetConfig<MapIconConfig>();
         
-        if (marker.Type == 1) {
+        if (marker.Type == 1 && config.ShowSubzoneLabels) {
             // subzone labels
             UpdateText((marker.RowId, marker.SubRowId), () => new MappyMapText {
                 TextId = (marker.RowId, marker.SubRowId),

--- a/Mappy/Controllers/Modules/MapIcons.cs
+++ b/Mappy/Controllers/Modules/MapIcons.cs
@@ -51,6 +51,13 @@ public class MapIcons : ModuleBase {
         
         if (marker.Type == 1 && config.ShowSubzoneLabels) {
             // subzone labels
+            UpdateIcon((marker.RowId, marker.SubRowId), () => new MappyMapIcon {
+                MarkerId = (marker.RowId, marker.SubRowId),
+                IconId = marker.Icon,
+                TexturePosition = marker.GetPosition(),
+                ColorManipulation = new Vector4(0.75f, 0.75f, 0.75f, 1.0f),
+            });
+
             UpdateText((marker.RowId, marker.SubRowId), () => new MappyMapText {
                 TextId = (marker.RowId, marker.SubRowId),
                 Text = GetTooltipString(marker),

--- a/Mappy/Controllers/Modules/MapIcons.cs
+++ b/Mappy/Controllers/Modules/MapIcons.cs
@@ -49,7 +49,20 @@ public class MapIcons : ModuleBase {
     private void DrawMarker(MapMarker marker, Map map) {
         var config = GetConfig<MapIconConfig>();
         
-        if (marker.Icon is > 063200 and < 63900 || map.Id.RawString.StartsWith("world")) {
+        if (marker.Type == 1) {
+            // subzone labels
+            UpdateText((marker.RowId, marker.SubRowId), () => new MappyMapText {
+                TextId = (marker.RowId, marker.SubRowId),
+                Text = GetTooltipString(marker),
+                TexturePosition = marker.GetPosition(),
+                UseLargeFont = false,
+                TextColor = KnownColor.Black.Vector(),
+                OutlineColor = KnownColor.White.Vector(),
+                HoverColor = KnownColor.Black.Vector(),
+                HoverOutlineColor = KnownColor.White.Vector(),
+                OnClick = marker.GetClickAction(),
+            });
+        } else if (marker.Icon is > 063200 and < 63900 || map.Id.RawString.StartsWith("world")) {
             UpdateIcon((marker.RowId, marker.SubRowId), () => new MappyMapIcon {
                 MarkerId = (marker.RowId, marker.SubRowId),
                 IconId = marker.Icon,

--- a/Mappy/Models/ModuleConfiguration/MapIconConfig.cs
+++ b/Mappy/Models/ModuleConfiguration/MapIconConfig.cs
@@ -42,4 +42,7 @@ public class MapIconConfig : IModuleConfig, IIconConfig, ITooltipConfig, IMapIco
 
     [BoolConfig("ShowTeleportCosts")]
     public bool ShowTeleportCostTooltips { get; set; } = true;
+
+    [BoolConfig("ShowSubzoneLabels")]
+    public bool ShowSubzoneLabels { get; set; } = true;
 }


### PR DESCRIPTION
This feature has been requested multiple times now, and it's really easy to implement. (#50 #71)
All it does is, it adds the subzone labels to the map:
![grafik](https://github.com/MidoriKami/Mappy/assets/38253929/8a94b036-927a-42cd-b1f8-dd37b43bbd40)

I understand your concern about performance, but I personally don't see any performance hit from rendering 4 additional zone labels.
If performance is really such a huge concern, I made this a toggleable option, which is - by default - enabled.

Thanks for your work!