### PR TITLE
Added style options for area and player cone

### DIFF
--- a/Mappy/Classes/DrawHelpers.cs
+++ b/Mappy/Classes/DrawHelpers.cs
@@ -22,6 +22,7 @@ public class MarkerInfo {
     public Func<string?>? SecondaryText { get; set; }
     public float? Radius { get; set; }
     public Vector4 RadiusColor { get; set; } = KnownColor.CornflowerBlue.Vector();
+    public Vector4 RadiusOutlineColor { get; set; } = KnownColor.CornflowerBlue.Vector();
     public Action? OnRightClicked { get; set; }
     public Action? OnLeftClicked { get; set; }
     public bool IsDynamicMarker { get; init; }
@@ -112,8 +113,8 @@ public static class DrawHelpers {
         
         var center = markerInfo.Position + markerInfo.Offset + ImGui.GetWindowPos();
         var radius = markerRadius * markerInfo.Scale * AgentMap.Instance()->CurrentMapSizeFactorFloat;
-        var fillColor = ImGui.GetColorU32(markerInfo.RadiusColor with { W = System.SystemConfig.AreaTransparency });
-        var radiusColor =  ImGui.GetColorU32(markerInfo.RadiusColor);
+        var fillColor = ImGui.GetColorU32(markerInfo.RadiusColor with { W = System.SystemConfig.AreaColor.W });
+        var radiusColor = ImGui.GetColorU32(markerInfo.RadiusOutlineColor with { W = System.SystemConfig.AreaOutlineColor.W });
             
         ImGui.GetWindowDrawList().AddCircleFilled(center, radius, fillColor);
         ImGui.GetWindowDrawList().AddCircle(center, radius, radiusColor, 0, 3.0f);

--- a/Mappy/Data/SystemConfig.cs
+++ b/Mappy/Data/SystemConfig.cs
@@ -63,7 +63,10 @@ public class SystemConfig : CharacterConfiguration {
     public bool ShowToolbarOnHover = true;
     public bool ScaleWithZoom = true;
     public bool AcceptedSpoilerWarning = false;
-    public Vector4 AreaColor = KnownColor.CornflowerBlue.Vector();
+    public Vector4 AreaColor = KnownColor.CornflowerBlue.Vector() with { W = 0.33f };
+    public Vector4 AreaOutlineColor = KnownColor.CornflowerBlue.Vector() with { W = 0.30f };
+    public Vector4 PlayerConeColor = KnownColor.CornflowerBlue.Vector() with { W = 0.33f };
+    public Vector4 PlayerConeOutlineColor = KnownColor.CornflowerBlue.Vector() with { W = 1.0f };
     public float AreaTransparency = 0.33f;
     public bool CenterOnFlag = true;
     public bool CenterOnGathering = true;

--- a/Mappy/Extensions/MapMarkerDataExtensions.cs
+++ b/Mappy/Extensions/MapMarkerDataExtensions.cs
@@ -15,6 +15,7 @@ public static class MapMarkerDataExtensions {
             IconId = marker.IconId,
             Radius = marker.Radius,
             RadiusColor = System.SystemConfig.AreaColor,
+            RadiusOutlineColor = System.SystemConfig.AreaOutlineColor,
             PrimaryText = () => marker.RecommendedLevel is 0 ? marker.TooltipString->ToString() : $"Lv. {marker.RecommendedLevel} {marker.TooltipString->ToString()}",
             IsDynamicMarker = true,
             ObjectiveId = marker.ObjectiveId,

--- a/Mappy/MapRenderer/MapRenderer.Player.cs
+++ b/Mappy/MapRenderer/MapRenderer.Player.cs
@@ -41,22 +41,25 @@ public partial class MapRenderer {
 
     private void DrawAngledLineFromCenter(Vector2 center, float lineLength, float angle) {
         var lineSegment = new Vector2(lineLength * MathF.Cos(angle), lineLength * MathF.Sin(angle));
-        ImGui.GetWindowDrawList().AddLine(center, center + lineSegment, ImGui.GetColorU32(KnownColor.CornflowerBlue.Vector()), 3.0f);
+        var coneOutlineColor = ImGui.GetColorU32(System.SystemConfig.PlayerConeOutlineColor);
+        ImGui.GetWindowDrawList().AddLine(center, center + lineSegment, coneOutlineColor, 3.0f);
     }
 
     private void DrawLineArcFromCenter(Vector2 center, float distance, float rotation) {
         var halfConeAngle = DegreesToRadians(90.0f) / 2.0f;
-        
+        var coneOutlineColor = ImGui.GetColorU32(System.SystemConfig.PlayerConeOutlineColor);
+
         var start = rotation - halfConeAngle;
         var stop = rotation + halfConeAngle;
         
         ImGui.GetWindowDrawList().PathArcTo(center, distance, start, stop);
-        ImGui.GetWindowDrawList().PathStroke(ImGui.GetColorU32(KnownColor.CornflowerBlue.Vector()), ImDrawFlags.None, 3.0f);
+        ImGui.GetWindowDrawList().PathStroke(coneOutlineColor, ImDrawFlags.None, 3.0f);
     }
 
     private void DrawFilledSemiCircle(Vector2 center, float distance, float rotation) {
         var halfConeAngle = DegreesToRadians(90.0f) / 2.0f;
         
+        var coneColor = ImGui.GetColorU32(System.SystemConfig.PlayerConeColor);
         var startAngle = rotation - halfConeAngle;
         var stopAngle = rotation + halfConeAngle;
         
@@ -65,7 +68,7 @@ public partial class MapRenderer {
         ImGui.GetWindowDrawList().PathArcTo(center, distance, startAngle, stopAngle);
         ImGui.GetWindowDrawList().PathLineTo(center);
         ImGui.GetWindowDrawList().PathLineTo(center + startPosition);
-        ImGui.GetWindowDrawList().PathFillConvex(ImGui.GetColorU32(KnownColor.CornflowerBlue.Vector() with { W = 0.33f }));
+        ImGui.GetWindowDrawList().PathFillConvex(coneColor);
     }
     
     // NumberArrayData[24] is specifically for the Map, subIndex 3 contains the current rotation, but square rotated it 90 degrees for some reason.

--- a/Mappy/Modules/FateModule.cs
+++ b/Mappy/Modules/FateModule.cs
@@ -24,6 +24,7 @@ public class FateModule : ModuleBase {
 
                     if (timeRemaining.TotalSeconds <= 300) {
                         markerInfo.RadiusColor = fate.GetColor();
+                        markerInfo.RadiusOutlineColor = fate.GetColor();
                     }
                 }
                 else {

--- a/Mappy/Windows/ConfigurationWindow.cs
+++ b/Mappy/Windows/ConfigurationWindow.cs
@@ -232,9 +232,10 @@ public class StyleOptionsTab : ITabItem {
         ImGui.Text("Area Style");
         ImGui.Separator();
         ImGuiHelpers.ScaledDummy(10.0f);
-        using (ImRaii.PushIndent()) {
-            configChanged |= ImGuiTweaks.ColorEditWithDefault("Area Color", ref System.SystemConfig.AreaColor, KnownColor.CornflowerBlue.Vector());
-            configChanged |= ImGui.DragFloat("Area Transparency", ref System.SystemConfig.AreaTransparency, 0.001f, 0.0f, 1.0f);
+        using (ImRaii.PushIndent())
+        {
+            configChanged |= ImGuiTweaks.ColorEditWithDefault("Area Color", ref System.SystemConfig.AreaColor, KnownColor.CornflowerBlue.Vector() with { W = 0.33f });
+            configChanged |= ImGuiTweaks.ColorEditWithDefault("Area Outline Color", ref System.SystemConfig.AreaOutlineColor, KnownColor.CornflowerBlue.Vector() with { W = 0.30f });
         }
 
         if (configChanged) {
@@ -262,9 +263,13 @@ public class PlayerOptionsTab : ITabItem {
         ImGuiHelpers.ScaledDummy(10.0f);
         using (ImRaii.PushIndent()) {
             configChanged |= ImGui.Checkbox("Scale Player Cone", ref System.SystemConfig.ScalePlayerCone);
-            
+
             ImGuiHelpers.ScaledDummy(5.0f);
             configChanged |= ImGui.DragFloat("Cone Size", ref System.SystemConfig.ConeSize, 0.25f);
+
+            ImGuiHelpers.ScaledDummy(5.0f);
+            configChanged |= ImGuiTweaks.ColorEditWithDefault("Cone Color", ref System.SystemConfig.PlayerConeColor, KnownColor.CornflowerBlue.Vector() with { W = 0.33f });
+            configChanged |= ImGuiTweaks.ColorEditWithDefault("Cone Outline Color", ref System.SystemConfig.PlayerConeOutlineColor, KnownColor.CornflowerBlue.Vector() with { W = 1.00f });
         }
         
         ImGuiHelpers.ScaledDummy(5.0f);


### PR DESCRIPTION
Hello, please review. I added various options for colors pertaining to areas and player cone. Area Transparency has been removed and instead uses the alpha set in Area Color

Related to #164 Area Style