### PR TITLE
fix: quest objective opening wrong map location

### DIFF
--- a/Mappy/Classes/CustomQuestSheet.cs
+++ b/Mappy/Classes/CustomQuestSheet.cs
@@ -17,7 +17,7 @@ public class CustomQuestSheet : Quest {
             
         for (var i = 0; i < 24; i++) {
             for (var j = 0; j < 8; j++) {
-                ToDoLocation[i, j] = new LazyRow< Level >(gameData, parser.ReadColumn< uint >( 1221 + (j * 24) + i ), language);
+                ToDoLocation[i, j] = new LazyRow< Level >(gameData, parser.ReadColumn< uint >( 1222 + (j * 24) + i ), language);
             }
         }
     }


### PR DESCRIPTION
Primary fix is in CustomQuestSheet.cs w/ the index of ToDoLocation[0][0] changed to 1222 instead of 1221

I noticed the that OpenMapInfo MapId was correct so Open Map now defaults to using the initial value and only tries a look up if the mapId is 0

GetMapIdForQuest has been changed to allow lookups for hidden quests. This would fix the case where an individual disabled tracking a quest but revisits it in their journal to find the quest location.

Note: Temporary markers persisting when changing areas via clicking visible green arrow connections on a map is ongoing