### PR TITLE
adds check to prevent temp marker draw if not on initially called map

### DIFF
--- a/Mappy/MapRenderer/MapRenderer.Temporary.cs
+++ b/Mappy/MapRenderer/MapRenderer.Temporary.cs
@@ -6,7 +6,12 @@ namespace Mappy.MapRenderer;
 
 public partial class MapRenderer {
     // Note, unlike EventMarkers, Temporary Markers seem to layer the icons in reverse.
-    private unsafe void DrawTemporaryMarkers() {
+    private unsafe void DrawTemporaryMarkers()
+    {
+        if (AgentMap.Instance()->SelectedMapSub != AgentMap.Instance()->SelectedMapId) {
+            return;
+        }
+
         var correctlySizedSpan = AgentMap.Instance()->TempMapMarkers;
         
         for (var index = 0; index < AgentMap.Instance()->TempMapMarkerCount; ++index) {


### PR DESCRIPTION
This may be a possible fix to the persistent temp markers... After taking a look at simpleTweaks Debug, I noticed that when the map is called via quest log, the Map Agent has prop SelectedMapSub set to the mapId to be shown, SelectedMapSub does not change when clicking on green map connections. When opening the map via hotkey or normally, SelectedMapSub dynamically changes with the currently showing mapId. 

My assumption is that if temp map markers are only generated when clicking on Quest Log, Gathering Log, Hunt Log etc then the MapAgent will display a mapId and lock the SelectedMapSub to that mapId. Blocking temp markers from being drawn if SelectedMapSub != MapId will prevent temp markers from persisting across connection/view parent clicks