### PR TITLE
Add subzone labels again

### DIFF
--- a/Mappy/Data/SystemConfig.cs
+++ b/Mappy/Data/SystemConfig.cs
@@ -87,6 +87,7 @@ public class SystemConfig : CharacterConfiguration {
     public bool ShowMapLabel = true;
     public bool ShowAreaLabel = true;
     public bool ShowSubAreaLabel = true;
+    public bool ShowSubzoneLabels = true;
 
     // Do not persist this setting
     [JsonIgnore] public bool DebugMode = false;

--- a/Mappy/Extensions/MapMarkerInfoExtensions.cs
+++ b/Mappy/Extensions/MapMarkerInfoExtensions.cs
@@ -44,6 +44,20 @@ public static class MapMarkerInfoExtensions {
         });
     }
 
+    public static unsafe void DrawText(this MapMarkerInfo marker, Vector2 offset, float scale) {
+        var tooltipText = MemoryHelper.ReadSeStringNullTerminated((nint)marker.MapMarker.Subtext);
+        var textFunc = GetMarkerPrimaryTooltip(marker, tooltipText);
+
+        DrawHelpers.DrawStaticMarkerText(new MarkerInfo {
+            Position = new Vector2(marker.MapMarker.X, marker.MapMarker.Y) / 16.0f * scale + DrawHelpers.GetMapCenterOffsetVector() * scale,
+            Offset = offset,
+            Scale = scale,
+            IconId = marker.MapMarker.IconId,
+            Radius = marker.MapMarker.Scale,
+            PrimaryText = textFunc
+        }, textFunc(), marker.MapMarker.SubtextOrientation);
+    }
+
     private static Aetheryte? GetAetheryteForAethernet(uint aethernetKey)
         => System.AetheryteAethernetCache.GetValue(aethernetKey);
 

--- a/Mappy/MapRenderer/MapRenderer.Static.cs
+++ b/Mappy/MapRenderer/MapRenderer.Static.cs
@@ -11,6 +11,8 @@ public partial class MapRenderer {
             if (marker.MapMarker.IconId is 0) continue;
             
             marker.Draw(DrawPosition, Scale);
+            if (!System.SystemConfig.ShowSubzoneLabels || marker.MapMarker.IconFlags != 0) continue;
+            marker.DrawText(DrawPosition, Scale);
         }
     }
 }

--- a/Mappy/Windows/ConfigurationWindow.cs
+++ b/Mappy/Windows/ConfigurationWindow.cs
@@ -81,7 +81,8 @@ public class MapFunctionsTab : ITabItem {
             configChanged |= ImGui.Checkbox("Show Misc Tooltips", ref System.SystemConfig.ShowMiscTooltips);
             configChanged |= ImGui.Checkbox("Lock Map on Center", ref System.SystemConfig.LockCenterOnMap);
             configChanged |= ImGui.Checkbox("Show Other Players", ref System.SystemConfig.ShowPlayers);
-            
+            configChanged |= ImGui.Checkbox("Show Subzone Labels", ref System.SystemConfig.ShowSubzoneLabels);
+
             ImGuiHelpers.ScaledDummy(5.0f);
             
             configChanged |= ImGui.Checkbox("Debug Mode", ref System.SystemConfig.DebugMode);


### PR DESCRIPTION
Adds the subzone labels once again, similar to https://github.com/MidoriKami/Mappy/pull/75.
This is what it looks like now, the text is a bit smaller and adjusted to the correct sides, just like the normal map.
It does scale correctly with the option "Scale icons with zoom".
There is also once again the option to turn it on/off in the settings.

![grafik](https://github.com/user-attachments/assets/95fee1c8-1153-4455-a1f3-68308b0ed400)
