### PR TITLE
Add option to disable focus on map window appear

### DIFF
--- a/Mappy/Data/SystemConfig.cs
+++ b/Mappy/Data/SystemConfig.cs
@@ -87,7 +87,7 @@ public class SystemConfig : CharacterConfiguration {
     public bool ShowMapLabel = true;
     public bool ShowAreaLabel = true;
     public bool ShowSubAreaLabel = true;
-    public bool NoFocusOnAppear = true;
+    public bool NoFocusOnAppear = false;
 
     // Do not persist this setting
     [JsonIgnore] public bool DebugMode = false;

--- a/Mappy/Data/SystemConfig.cs
+++ b/Mappy/Data/SystemConfig.cs
@@ -87,6 +87,7 @@ public class SystemConfig : CharacterConfiguration {
     public bool ShowMapLabel = true;
     public bool ShowAreaLabel = true;
     public bool ShowSubAreaLabel = true;
+    public bool NoFocusOnAppear = true;
 
     // Do not persist this setting
     [JsonIgnore] public bool DebugMode = false;

--- a/Mappy/Windows/ConfigurationWindow.cs
+++ b/Mappy/Windows/ConfigurationWindow.cs
@@ -81,6 +81,7 @@ public class MapFunctionsTab : ITabItem {
             configChanged |= ImGui.Checkbox("Show Misc Tooltips", ref System.SystemConfig.ShowMiscTooltips);
             configChanged |= ImGui.Checkbox("Lock Map on Center", ref System.SystemConfig.LockCenterOnMap);
             configChanged |= ImGui.Checkbox("Show Other Players", ref System.SystemConfig.ShowPlayers);
+            configChanged |= ImGui.Checkbox("Disable Map Focus on Appear", ref System.SystemConfig.NoFocusOnAppear);
             
             ImGuiHelpers.ScaledDummy(5.0f);
             

--- a/Mappy/Windows/MapWindow.cs
+++ b/Mappy/Windows/MapWindow.cs
@@ -231,6 +231,13 @@ public class MapWindow : Window {
             Flags &= ~(ImGuiWindowFlags.NoResize | ImGuiWindowFlags.NoMove);
         }
 
+        if (System.SystemConfig.NoFocusOnAppear) {
+            Flags |= ImGuiWindowFlags.NoFocusOnAppearing;
+        }
+        else {
+            Flags &= ~(ImGuiWindowFlags.NoFocusOnAppearing);
+        }
+
         RespectCloseHotkey = !System.SystemConfig.IgnoreEscapeKey;
 
         if (RespectCloseHotkey && Service.KeyState[VirtualKey.ESCAPE] && IsFocused) {


### PR DESCRIPTION
Can't remember if this behavior existed prior to 7.1 but noticed it when moving from zone to zone.

Added checkbox under "Misc Options" to enable/disable this.