### PR TITLE
Fix Cosmic Exploration map markers not showing 

### DIFF
--- a/Mappy/Controllers/IntegrationsController.cs
+++ b/Mappy/Controllers/IntegrationsController.cs
@@ -205,10 +205,12 @@ public unsafe class IntegrationsController : IDisposable {
 				.Value.Map.RowId;
 		}
 
-		return Service.DataManager.GetExcelSheet<Quest>().FirstOrDefault(quest =>
+		var fallbackQuest = Service.DataManager.GetExcelSheet<Quest>().FirstOrDefault(quest =>
 			IsNameMatch(quest.Name.ExtractText(), mapInfo) &&
-			quest is { IssuerLocation.RowId: not 0 })
-			.IssuerLocation.Value.Map.RowId;
+			quest is { IssuerLocation.RowId: not 0 });
+		
+		if (fallbackQuest.RowId == 0) return null;
+		return fallbackQuest.IssuerLocation.RowId;
 	}
 
 	private static bool IsNameMatch(string name, OpenMapInfo* mapInfo) 

--- a/Mappy/MapRenderer/MapRenderer.Dynamic.cs
+++ b/Mappy/MapRenderer/MapRenderer.Dynamic.cs
@@ -13,6 +13,8 @@ public partial class MapRenderer {
         for (var index = 0; index < AgentMap.Instance()->EventMarkers.Count; ++index) {
             var marker = AgentMap.Instance()->EventMarkers[index];
             if (marker.IconId is 0) continue;
+            // Fixes Cosmic exploration mech op markers duplicated markers
+            if (marker.MarkerType is 5 && marker.IconId == 60493) continue;
 
             // If there's at least one more marker after this
             if (index < AgentMap.Instance()->EventMarkers.Count - 1) {

--- a/Mappy/MapRenderer/MapRenderer.Temporary.cs
+++ b/Mappy/MapRenderer/MapRenderer.Temporary.cs
@@ -22,6 +22,9 @@ public partial class MapRenderer {
                 
                 // Check if the next marker matches our position, and that the next marker has a radius, and we do not.
                 if (currentPosition == nextPosition && marker.MapMarker.Scale <= 1.0f && nextMarker.MapMarker.Scale > 1.0f) {
+                    // to cover cosmic exploration missions that do not set a icon id
+                    if (marker.MapMarker.IconId == 0)
+                        marker.MapMarker.IconId = 60492;
                     
                     // Set the next marker's radius (writing to a copy of the marker, not mutating the original data)
                     marker.MapMarker.Scale = nextMarker.MapMarker.Scale;


### PR DESCRIPTION
Fixes gatherer missions in Cosmic Exploration not showing the area when clicking view on map from the mission (#209). As mentioned on the issue, it seems they did not set the IconId for these and I can see no other differences between these and leves (for example) that might make distinguishing them easier. Also changes `GetMapIdForQuest` to allow not finding any match.

I also removed the duplicate marker for Mech Ops (kind of fates) but that is an optional fix. I asked for help trying to find a way to replicate the FATE behavior where it lists the time remaining and more details for both Mech Ops and Red Alerts (both time fate like things that are not in the fate director). If I am able to figure that out, will make another PR (and you are open to that) 

However, I do know mappy was very complicated to get working, there are lot of edge cases and weird/awful things the game does so I might not have considered everything.