### PR TITLE
Change text scale behavior

### DIFF
--- a/Mappy/Classes/DrawHelpers.cs
+++ b/Mappy/Classes/DrawHelpers.cs
@@ -158,15 +158,19 @@ public static class DrawHelpers {
         }
     }
 
-    public static void DrawText(MarkerInfo markerInfo, SeString text)
-        => DrawText(markerInfo, text.ToString());
+    public static void DrawText(MarkerInfo markerInfo, SeString text, Single subtextStyle)
+        => DrawText(markerInfo, text.ToString(), subtextStyle);
     
-    public static void DrawText(MarkerInfo markerInfo, string text) {
+    public static void DrawText(MarkerInfo markerInfo, string text, Single subtextStyle) {
         // Don't draw markers that are positioned off the map texture
         if (markerInfo.Position.X < 0.0f || markerInfo.Position.X > 2048.0f * markerInfo.Scale || markerInfo.Position.Y < 0.0f || markerInfo.Position.Y > 2048.0f * markerInfo.Scale) return;
 
-        var scale = System.SystemConfig.ScaleTextWithZoom ? 0.20f * markerInfo.Scale : 0.5f;
-        
+        var textScale = subtextStyle switch {
+            1 => System.SystemConfig.LargeAreaTextScale,
+            _ => System.SystemConfig.SmallAreaTextScale,
+        };
+        var scale = 0.20f * textScale * (System.SystemConfig.ScaleTextWithZoom ? markerInfo.Scale : 1.0f);
+
         using var largeFont = System.LargeAxisFontHandle.Push();
         ImGui.SetWindowFontScale(scale);
 

--- a/Mappy/Classes/DrawHelpers.cs
+++ b/Mappy/Classes/DrawHelpers.cs
@@ -158,10 +158,10 @@ public static class DrawHelpers {
         }
     }
 
-    public static void DrawText(MarkerInfo markerInfo, SeString text, Single subtextStyle)
+    public static void DrawText(MarkerInfo markerInfo, SeString text, uint subtextStyle)
         => DrawText(markerInfo, text.ToString(), subtextStyle);
     
-    public static void DrawText(MarkerInfo markerInfo, string text, Single subtextStyle) {
+    public static void DrawText(MarkerInfo markerInfo, string text, uint subtextStyle) {
         // Don't draw markers that are positioned off the map texture
         if (markerInfo.Position.X < 0.0f || markerInfo.Position.X > 2048.0f * markerInfo.Scale || markerInfo.Position.Y < 0.0f || markerInfo.Position.Y > 2048.0f * markerInfo.Scale) return;
 

--- a/Mappy/Extensions/MapMarkerInfoExtensions.cs
+++ b/Mappy/Extensions/MapMarkerInfoExtensions.cs
@@ -46,12 +46,10 @@ public static class MapMarkerInfoExtensions {
         
         if (marker.MapMarker.IconId is 0 && marker.MapMarker.Index is not 0) {
             if (System.SystemConfig.ShowTextLabels) {
-                markerInfo.Scale *= marker.MapMarker.SubtextStyle switch {
-                    1 => System.SystemConfig.LargeAreaTextScale,
-                    _ => System.SystemConfig.SmallAreaTextScale,
-                };
+
+                var subtextStyle = marker.MapMarker.SubtextStyle;
             
-                DrawHelpers.DrawText(markerInfo, tooltipText);
+                DrawHelpers.DrawText(markerInfo, tooltipText, subtextStyle);
             }
         }
         else {


### PR DESCRIPTION
Opening to start a small discussion surrounding how the text scaling currently works and to potentially bring it more in line with how the icon scaling behavior currently functions.

Currently, unchecking `Scale text labels with zoom` ignores the `Large Label Scale` and `Small Label Scale` settings which does not mirror how the `Icon Scale` setting functions.